### PR TITLE
NPE fix for missing default color.

### DIFF
--- a/src/pulltorefresh.android.ts
+++ b/src/pulltorefresh.android.ts
@@ -138,6 +138,11 @@ export class PullToRefresh extends PullToRefreshBase {
 
   [colorProperty.setNative](value: Color | number) {
     const color = value instanceof Color ? value.android : value;
+    // Default content color (required for text)
+    if (this.content && !this.content.style.color)
+    {
+      this.content.style.color = color;
+    }
     this.nativeView.setColorSchemeColors([color]);
   }
 


### PR DESCRIPTION
This fixes NPE caused by TextBase components inside container that have no color set.
Android TextView cannot accept null value in 'setTextColor'.