### PR TITLE
Android TextView NPE fix.

### DIFF
--- a/src/pulltorefresh-common.ts
+++ b/src/pulltorefresh-common.ts
@@ -9,20 +9,6 @@ export class PullToRefreshBase extends ContentView
   public static refreshEvent = 'refresh';
 
   public refreshing: boolean;
-
-  public _addChildFromBuilder(name: string, value: any) {
-    // copy inheritable style property values
-    const originalColor = value.style.color || null;
-    const originaBackgroundColor = value.style.backgroundColor || null;
-
-    if (value instanceof View) {
-      this.content = value;
-    }
-
-    // reset inheritable style property values as we do not want those to be inherited
-    value.style.color = originalColor;
-    value.style.backgroundColor = originaBackgroundColor;
-  }
 }
 
 export const refreshingProperty = new Property<PullToRefreshBase, boolean>({


### PR DESCRIPTION
This overridden method prevents color from being inherited, therefore color is null and an NPE is thrown for android TextViews that have no color. See #38.
Also, it seems to be useless as logic is handled by ContentView.