### PR TITLE
NPE fix & Implementation of 'indicatorColor' and 'indicatorFillColor'

### DIFF
--- a/publish/pack.sh
+++ b/publish/pack.sh
@@ -7,28 +7,28 @@ ROOT_DIR=..
 PUBLISH=--publish
 
 install() {
-    npm i
+    npm.cmd i
 }
 
 pack() {
 
     echo 'Clearing /src and /package...'
-    node_modules/.bin/rimraf "$TO_SOURCE_DIR"
-    node_modules/.bin/rimraf "$PACK_DIR"
+    node_modules/.bin/rimraf.cmd "$TO_SOURCE_DIR"
+    node_modules/.bin/rimraf.cmd "$PACK_DIR"
 
     # copy src
     echo 'Copying src...'
-    node_modules/.bin/ncp "$SOURCE_DIR" "$TO_SOURCE_DIR"
+    node_modules/.bin/ncp.cmd "$SOURCE_DIR" "$TO_SOURCE_DIR"
 
     # copy README & LICENSE to src
     echo 'Copying README and LICENSE to /src...'
-    node_modules/.bin/ncp "$ROOT_DIR"/LICENSE.md "$TO_SOURCE_DIR"/LICENSE.md
-    node_modules/.bin/ncp "$ROOT_DIR"/README.md "$TO_SOURCE_DIR"/README.md
+    node_modules/.bin/ncp.cmd "$ROOT_DIR"/LICENSE.md "$TO_SOURCE_DIR"/LICENSE.md
+    node_modules/.bin/ncp.cmd "$ROOT_DIR"/README.md "$TO_SOURCE_DIR"/README.md
 
     # compile package and copy files required by npm
     echo 'Building /src...'
     cd "$TO_SOURCE_DIR"
-    node_modules/.bin/tsc
+    node_modules/.bin/tsc.cmd
     cd ..
 
     echo 'Creating package...'
@@ -37,11 +37,11 @@ pack() {
 
     # create the package
     cd "$PACK_DIR"
-    npm pack ../"$TO_SOURCE_DIR"
+    npm.cmd pack ../"$TO_SOURCE_DIR"
 
     # delete source directory used to create the package
     cd ..
-    node_modules/.bin/rimraf "$TO_SOURCE_DIR"
+    node_modules/.bin/rimraf.cmd "$TO_SOURCE_DIR"
 }
 
 install && pack

--- a/publish/pack.sh
+++ b/publish/pack.sh
@@ -7,28 +7,28 @@ ROOT_DIR=..
 PUBLISH=--publish
 
 install() {
-    npm.cmd i
+    npm i
 }
 
 pack() {
 
     echo 'Clearing /src and /package...'
-    node_modules/.bin/rimraf.cmd "$TO_SOURCE_DIR"
-    node_modules/.bin/rimraf.cmd "$PACK_DIR"
+    node_modules/.bin/rimraf "$TO_SOURCE_DIR"
+    node_modules/.bin/rimraf "$PACK_DIR"
 
     # copy src
     echo 'Copying src...'
-    node_modules/.bin/ncp.cmd "$SOURCE_DIR" "$TO_SOURCE_DIR"
+    node_modules/.bin/ncp "$SOURCE_DIR" "$TO_SOURCE_DIR"
 
     # copy README & LICENSE to src
     echo 'Copying README and LICENSE to /src...'
-    node_modules/.bin/ncp.cmd "$ROOT_DIR"/LICENSE.md "$TO_SOURCE_DIR"/LICENSE.md
-    node_modules/.bin/ncp.cmd "$ROOT_DIR"/README.md "$TO_SOURCE_DIR"/README.md
+    node_modules/.bin/ncp "$ROOT_DIR"/LICENSE.md "$TO_SOURCE_DIR"/LICENSE.md
+    node_modules/.bin/ncp "$ROOT_DIR"/README.md "$TO_SOURCE_DIR"/README.md
 
     # compile package and copy files required by npm
     echo 'Building /src...'
     cd "$TO_SOURCE_DIR"
-    node_modules/.bin/tsc.cmd
+    node_modules/.bin/tsc
     cd ..
 
     echo 'Creating package...'
@@ -37,11 +37,11 @@ pack() {
 
     # create the package
     cd "$PACK_DIR"
-    npm.cmd pack ../"$TO_SOURCE_DIR"
+    npm pack ../"$TO_SOURCE_DIR"
 
     # delete source directory used to create the package
     cd ..
-    node_modules/.bin/rimraf.cmd "$TO_SOURCE_DIR"
+    node_modules/.bin/rimraf "$TO_SOURCE_DIR"
 }
 
 install && pack

--- a/src/pulltorefresh-common.ts
+++ b/src/pulltorefresh-common.ts
@@ -1,5 +1,8 @@
+import { Color } from 'tns-core-modules/color';
 import { ContentView } from 'tns-core-modules/ui/content-view';
-import { Property, View } from 'tns-core-modules/ui/core/view';
+import { CssProperty, Property } from 'tns-core-modules/ui/core/properties';
+import { View } from 'tns-core-modules/ui/core/view';
+import { Style } from 'tns-core-modules/ui/styling/style';
 import { PullToRefresh as PullToRefreshDefinition } from '.';
 
 export * from 'tns-core-modules/ui/content-view';
@@ -9,20 +12,6 @@ export class PullToRefreshBase extends ContentView
   public static refreshEvent = 'refresh';
 
   public refreshing: boolean;
-
-  public _addChildFromBuilder(name: string, value: any) {
-    // copy inheritable style property values
-    const originalColor = value.style.color || null;
-    const originaBackgroundColor = value.style.backgroundColor || null;
-
-    if (value instanceof View) {
-      this.content = value;
-    }
-
-    // reset inheritable style property values as we do not want those to be inherited
-    value.style.color = originalColor;
-    value.style.backgroundColor = originaBackgroundColor;
-  }
 }
 
 export const refreshingProperty = new Property<PullToRefreshBase, boolean>({
@@ -30,3 +19,65 @@ export const refreshingProperty = new Property<PullToRefreshBase, boolean>({
   defaultValue: false
 });
 refreshingProperty.register(PullToRefreshBase);
+
+export const indicatorColorProperty = new Property<PullToRefreshBase, Color>(
+{
+    name: 'indicatorColor',
+    affectsLayout: true,
+    valueConverter: (v) =>
+    {
+      if (!Color.isValid(v))
+      {
+        return null;
+      }
+      return new Color(v);
+    }
+});
+indicatorColorProperty.register(PullToRefreshBase);
+
+export const indicatorColorStyleProperty = new CssProperty<Style, Color>(
+{
+    name: 'indicatorColorStyle',
+    cssName: 'indicator-color',
+    affectsLayout: true,
+    valueConverter: (v) =>
+    {
+      if (!Color.isValid(v))
+      {
+        return null;
+      }
+      return new Color(v);
+    }
+});
+indicatorColorStyleProperty.register(Style);
+
+export const indicatorFillColorProperty = new Property<PullToRefreshBase, Color>(
+{
+    name: 'indicatorFillColor',
+    affectsLayout: true,
+    valueConverter: (v) =>
+    {
+      if (!Color.isValid(v))
+      {
+        return null;
+      }
+      return new Color(v);
+    }
+});
+indicatorFillColorProperty.register(PullToRefreshBase);
+
+export const indicatorFillColorStyleProperty = new CssProperty<Style, Color>(
+{
+    name: 'indicatorFillColorStyle',
+    cssName: 'indicator-fill-color',
+    affectsLayout: true,
+    valueConverter: (v) =>
+    {
+      if (!Color.isValid(v))
+      {
+        return null;
+      }
+      return new Color(v);
+    }
+});
+indicatorFillColorStyleProperty.register(Style);

--- a/src/pulltorefresh.android.ts
+++ b/src/pulltorefresh.android.ts
@@ -1,10 +1,5 @@
 import { Color } from 'tns-core-modules/color';
-import {
-  backgroundColorProperty,
-  colorProperty,
-  PullToRefreshBase,
-  refreshingProperty
-} from './pulltorefresh-common';
+import * as common from './pulltorefresh-common';
 
 export * from './pulltorefresh-common';
 
@@ -55,7 +50,7 @@ class CarouselFriendlySwipeRefreshLayout extends SwipeRefreshLayout_Namespace.Sw
   }
 }
 
-export class PullToRefresh extends PullToRefreshBase {
+export class PullToRefresh extends common.PullToRefreshBase {
   private _androidViewId: number;
 
   public nativeView: androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -84,7 +79,7 @@ export class PullToRefresh extends PullToRefreshBase {
             if (owner) {
               owner.refreshing = true;
               owner.notify({
-                eventName: PullToRefreshBase.refreshEvent,
+                eventName: common.PullToRefreshBase.refreshEvent,
                 object: owner
               });
             }
@@ -102,7 +97,7 @@ export class PullToRefresh extends PullToRefreshBase {
           if (owner) {
             owner.refreshing = true;
             owner.notify({
-              eventName: PullToRefreshBase.refreshEvent,
+              eventName: common.PullToRefreshBase.refreshEvent,
               object: owner
             });
           }
@@ -129,20 +124,40 @@ export class PullToRefresh extends PullToRefreshBase {
     super.disposeNativeView();
   }
 
-  [refreshingProperty.getDefault](): boolean {
+  [common.refreshingProperty.getDefault](): boolean {
     return false;
   }
-  [refreshingProperty.setNative](value: boolean) {
+  [common.refreshingProperty.setNative](value: boolean) {
     this.nativeView.setRefreshing(value);
   }
 
-  [colorProperty.setNative](value: Color | number) {
-    const color = value instanceof Color ? value.android : value;
+  [common.indicatorColorProperty.setNative](value: Color) {
+    const color = value ? value.android : this.color;
     this.nativeView.setColorSchemeColors([color]);
   }
 
-  [backgroundColorProperty.setNative](value: Color | number) {
-    const color = value instanceof Color ? value.android : value;
+  [common.indicatorColorStyleProperty.setNative](value: Color) {
+    // Inline property has priority
+    if (this.indicatorColor)
+    {
+      return;
+    }
+    const color = value ? value.android : this.color;
+    this.nativeView.setColorSchemeColors([color]);
+  }
+
+  [common.indicatorFillColorProperty.setNative](value: Color) {
+    const color = value ? value.android : this.backgroundColor;
+    this.nativeView.setProgressBackgroundColorSchemeColor(color);
+  }
+
+  [common.indicatorFillColorStyleProperty.setNative](value: Color) {
+    // Inline property has priority
+    if (this.indicatorFillColor)
+    {
+      return;
+    }
+    const color = value ? value.android : this.backgroundColor;
     this.nativeView.setProgressBackgroundColorSchemeColor(color);
   }
 }

--- a/src/pulltorefresh.android.ts
+++ b/src/pulltorefresh.android.ts
@@ -1,4 +1,3 @@
-import { Color } from 'tns-core-modules/color';
 import * as common from './pulltorefresh-common';
 
 export * from './pulltorefresh-common';
@@ -131,14 +130,14 @@ export class PullToRefresh extends common.PullToRefreshBase {
     this.nativeView.setRefreshing(value);
   }
 
-  [common.indicatorColorProperty.setNative](value: Color) {
+  [common.indicatorColorProperty.setNative](value: any) {
     const color = value ? value.android : this.color;
     this.nativeView.setColorSchemeColors([color]);
   }
 
-  [common.indicatorColorStyleProperty.setNative](value: Color) {
+  [common.indicatorColorStyleProperty.setNative](value: any) {
     // Inline property has priority
-    if (this.indicatorColor)
+    if ((this as any).indicatorColor)
     {
       return;
     }
@@ -146,14 +145,14 @@ export class PullToRefresh extends common.PullToRefreshBase {
     this.nativeView.setColorSchemeColors([color]);
   }
 
-  [common.indicatorFillColorProperty.setNative](value: Color) {
+  [common.indicatorFillColorProperty.setNative](value: any) {
     const color = value ? value.android : this.backgroundColor;
     this.nativeView.setProgressBackgroundColorSchemeColor(color);
   }
 
-  [common.indicatorFillColorStyleProperty.setNative](value: Color) {
+  [common.indicatorFillColorStyleProperty.setNative](value: any) {
     // Inline property has priority
-    if (this.indicatorFillColor)
+    if ((this as any).indicatorFillColor)
     {
       return;
     }

--- a/src/pulltorefresh.ios.ts
+++ b/src/pulltorefresh.ios.ts
@@ -1,11 +1,6 @@
 import { Color } from 'tns-core-modules/color';
 import { ios as iosUtils } from 'tns-core-modules/utils/utils';
-import {
-  backgroundColorProperty,
-  colorProperty,
-  PullToRefreshBase,
-  refreshingProperty
-} from './pulltorefresh-common';
+import * as common from './pulltorefresh-common';
 
 export * from './pulltorefresh-common';
 
@@ -28,7 +23,7 @@ class PullToRefreshHandler extends NSObject {
     const pullToRefresh = this._owner.get();
     pullToRefresh.refreshing = true;
     pullToRefresh.notify({
-      eventName: PullToRefreshBase.refreshEvent,
+      eventName: common.PullToRefreshBase.refreshEvent,
       object: pullToRefresh
     });
   }
@@ -36,7 +31,7 @@ class PullToRefreshHandler extends NSObject {
 
 const SUPPORT_REFRESH_CONTROL = iosUtils.MajorVersion >= 10;
 
-export class PullToRefresh extends PullToRefreshBase {
+export class PullToRefresh extends common.PullToRefreshBase {
   private _handler: PullToRefreshHandler;
 
   // NOTE: We cannot use the default ios property as the UIRefreshControl can be added only to UIScrollViews!
@@ -103,10 +98,10 @@ export class PullToRefresh extends PullToRefreshBase {
     }
   }
 
-  [refreshingProperty.getDefault](): boolean {
+  [common.refreshingProperty.getDefault](): boolean {
     return false;
   }
-  [refreshingProperty.setNative](value: boolean) {
+  [common.refreshingProperty.setNative](value: boolean) {
     if (value) {
       this.refreshControl.beginRefreshing();
     } else {
@@ -114,21 +109,49 @@ export class PullToRefresh extends PullToRefreshBase {
     }
   }
 
-  [colorProperty.getDefault](): UIColor {
+  [common.indicatorColorProperty.getDefault](): UIColor {
     return this.refreshControl.tintColor;
   }
-  [colorProperty.setNative](value: Color | UIColor) {
-    const color = value instanceof Color ? value.ios : value;
 
+  [common.indicatorColorProperty.setNative](value: Color) {
+    const color = value ? value.ios : this.color;
     this.refreshControl.tintColor = color;
   }
 
-  [backgroundColorProperty.getDefault](): UIColor {
+  [common.indicatorColorStyleProperty.getDefault](): UIColor {
+    return this.refreshControl.tintColor;
+  }
+
+  [common.indicatorColorStyleProperty.setNative](value: Color) {
+    // Inline property has priority
+    if (this.indicatorColor)
+    {
+      return;
+    }
+    const color = value ? value.ios : this.color;
+    this.refreshControl.tintColor = color;
+  }
+
+  [common.indicatorFillColorProperty.getDefault](): UIColor {
     return this.refreshControl.backgroundColor;
   }
-  [backgroundColorProperty.setNative](value: Color | UIColor) {
-    const color = value instanceof Color ? value.ios : value;
 
+  [common.indicatorFillColorProperty.setNative](value: Color) {
+    const color = value ? value.ios : this.backgroundColor;
+    this.refreshControl.backgroundColor = color;
+  }
+
+  [common.indicatorFillColorStyleProperty.getDefault](): UIColor {
+    return this.refreshControl.backgroundColor;
+  }
+
+  [common.indicatorFillColorStyleProperty.setNative](value: Color) {
+    // Inline property has priority
+    if (this.indicatorFillColor)
+    {
+      return;
+    }
+    const color = value ? value.ios : this.backgroundColor;
     this.refreshControl.backgroundColor = color;
   }
 }

--- a/src/pulltorefresh.ios.ts
+++ b/src/pulltorefresh.ios.ts
@@ -1,4 +1,3 @@
-import { Color } from 'tns-core-modules/color';
 import { ios as iosUtils } from 'tns-core-modules/utils/utils';
 import * as common from './pulltorefresh-common';
 
@@ -113,7 +112,7 @@ export class PullToRefresh extends common.PullToRefreshBase {
     return this.refreshControl.tintColor;
   }
 
-  [common.indicatorColorProperty.setNative](value: Color) {
+  [common.indicatorColorProperty.setNative](value: any) {
     const color = value ? value.ios : this.color;
     this.refreshControl.tintColor = color;
   }
@@ -122,9 +121,9 @@ export class PullToRefresh extends common.PullToRefreshBase {
     return this.refreshControl.tintColor;
   }
 
-  [common.indicatorColorStyleProperty.setNative](value: Color) {
+  [common.indicatorColorStyleProperty.setNative](value: any) {
     // Inline property has priority
-    if (this.indicatorColor)
+    if ((this as any).indicatorColor)
     {
       return;
     }
@@ -136,7 +135,7 @@ export class PullToRefresh extends common.PullToRefreshBase {
     return this.refreshControl.backgroundColor;
   }
 
-  [common.indicatorFillColorProperty.setNative](value: Color) {
+  [common.indicatorFillColorProperty.setNative](value: any) {
     const color = value ? value.ios : this.backgroundColor;
     this.refreshControl.backgroundColor = color;
   }
@@ -145,9 +144,9 @@ export class PullToRefresh extends common.PullToRefreshBase {
     return this.refreshControl.backgroundColor;
   }
 
-  [common.indicatorFillColorStyleProperty.setNative](value: Color) {
+  [common.indicatorFillColorStyleProperty.setNative](value: any) {
     // Inline property has priority
-    if (this.indicatorFillColor)
+    if ((this as any).indicatorFillColor)
     {
       return;
     }


### PR DESCRIPTION
The meaning of this commit is to separate background and text colors from PullToRefresh colors.

1) Using 'indicator-color' css property or 'indicatorColor' component property, one can change arrow color.
2) Using 'indicator-fill-color' css property or 'indicatorFillColor' component property, one can change circle color.
3) This custom property system is designed in such a way that component property will always override css property (just as it should be).
4) These properties use default 'color' and 'backgroundColor' values.
5) There is no need to support native color codes, as NS components don't accept them too.

One drawback of this commit is that I was unable to test it on iOS devices.

This also fixes #38 as the '_addChildFromBuilder' hack you used caused an Android NPE to be thrown due to nested Label without defined color.